### PR TITLE
2 small improvements

### DIFF
--- a/bin/npm2es.js
+++ b/bin/npm2es.js
@@ -87,7 +87,8 @@ function beginFollowing() {
   follow({
     db: argv.couch,
     since: since,
-    include_docs: true
+    include_docs: true,
+    inactivity_ms: 1000 * 60 * 60
   },  function(err, change) {
     if (err) {
       return console.error('ERROR:', err.message, argv.couch);


### PR DESCRIPTION
The first just logs the reason WHY es couldn't connect when there's a connection failure.  (Useful for debugging startup failures.)

The second sets the inactivity_ms to 1 hour.  If there aren't any packages published within that time, then probably something is wrong and the connection is stale anyway, so just die and restart.  (Since it stashes the sequence in es, then restarting is fine.)
