### PR TITLE
Adding ability to configure the inactivity_ms argument for the follow…

### DIFF
--- a/bin/npm2es.js
+++ b/bin/npm2es.js
@@ -95,7 +95,7 @@ function beginFollowing() {
     db: argv.couch,
     since: since,
     include_docs: true,
-    inactivity_ms: 1000 * 60 * 60
+    inactivity_ms: argv.timeout || 1000 * 60 * 60
   },  function(err, change) {
 
     if (err) {


### PR DESCRIPTION
… module through the timeout argument to npm2es.

This is needed to override the default 1 hour inactivitiy_ms argument to the follow module