### PR TITLE
Adding support for indexing scoped npm packages

### DIFF
--- a/bin/npm2es.js
+++ b/bin/npm2es.js
@@ -153,6 +153,11 @@ function beginFollowing() {
         return;
       }
 
+      // Encoding to allow scoped packages to be indexed by elasticsearch
+      if(p.name[0] == '@') {
+        p.name = p.name.replace('/','%2f')
+      }
+
       this.pause();
       request.get({
         url: ES + '/package/' + p.name,


### PR DESCRIPTION
This enables scoped packages of the format "@scope/packagename" to be indexed into elasticsearch by replacing the '/' character with an encoded '%2f', so the PUT into elasticsearch treats '@scope%2fpackagename' as the full package name.